### PR TITLE
Fix admin panel language redirection

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -8,5 +8,5 @@ export default createMiddleware({
 })
 
 export const config = {
-	matcher: ['/((?!api|_next|_vercel|.*\\..*).*)'],
+	matcher: ['/((?!api|_next|_vercel|admin|.*\\..*).*)'],
 }


### PR DESCRIPTION
Exclude `/admin` from `next-intl` middleware to stop redirection to locale-prefixed admin paths.

---
<a href="https://cursor.com/background-agent?bcId=bc-00fbd8f8-fb55-44ef-904c-1c0fc8474a4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-00fbd8f8-fb55-44ef-904c-1c0fc8474a4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

